### PR TITLE
Update SolPretty.sol: Some optimizations

### DIFF
--- a/src/SolPretty.sol
+++ b/src/SolPretty.sol
@@ -58,8 +58,8 @@ library SolPretty {
         uint256 displayDecimals; //        default type(uint256).max
         bytes1 decimalDelimter; //         default "."
         bytes1 fractionalDelimiter; //     default " "
-        uint256 fractionalGroupingSize; // default 0
         bytes1 integerDelimiter; //        default ","
+        uint256 fractionalGroupingSize; // default 0
         uint256 integerGroupingSize; //    default 3
         uint256 fixedWidth; //             default 0 (automatic)
     }
@@ -73,7 +73,7 @@ library SolPretty {
     }
 
     function log(string[] memory messages) internal pure {
-        for (uint256 i = 0; i < messages.length; i++) {
+        for (uint256 i; i < messages.length; ++i) {
             log(messages[i]);
         }
     }
@@ -84,7 +84,7 @@ library SolPretty {
 
     function concat(string[] memory strings) internal pure returns (string memory result) {
         result = "";
-        for (uint256 i = 0; i < strings.length; i++) {
+        for (uint256 i; i < strings.length; ++i) {
             result = result.concat(strings[i]);
         }
     }
@@ -229,7 +229,7 @@ library SolPretty {
             // zero represents the decimal delimiter position
             // for example FP6 12345678 starts at cursor -6 and ends at cursor 2
             int256 cursor = adjustedDecimals > 0 ? (-1 * int256(adjustedDecimals)) : int256(1);
-            uint256 counter = 0;
+            uint256 counter;
             while (counter < length) {
                 assembly {
                     ptr := sub(ptr, 1)


### PR DESCRIPTION
Three Types of changes made in this file to improve gas optimizations:

First is struct-packing: The reason is well explained here -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#pack-structs-in-solidity

2nd change : `uint256 i = 0;` to `uint256 i;`
Cuz the default value of all unsigned integers used to be 0. So, it's a waste of gas in the way these variables were initialized

3rd change: `i++` to `++i` in for loops
That's because using `++i` is more gas efficient that `i++` and it also doesn't mess with any code logic

Moreover there's one more suggestion: You can use the `unchecked` block inside those for loops in order to enhance these for loops even more.

Thanks! 