### PR TITLE
Fix import in readme and lower version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ forge install devtooligan/solpretty
  - pp(uint256 value, memory SolPrettyOptions)
 
 ```solidity
-import {pp} from "solpretty/src/solpretty.sol";
+import {pp} from "solpretty/solpretty.sol";
 
 pp(123123123123) //            -> "123,123,123,123" //  default
 pp(123123123123, 6) //         -> "123,123.123123" //   fixedDecimals = 6

--- a/src/SolPretty.sol
+++ b/src/SolPretty.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.0;
 
 /**
  *                         ,dPYb,                                   I8      I8


### PR DESCRIPTION
- Looks like forge will automatically set the remapping to include /src/ when installing, so I updated the readme example
- Currently will only compile with v0.8.19 and above so I set the version to ^v0.8.0 to be a little more accommodating